### PR TITLE
Replace all `@panic`s with error logging without changing the API

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -15,7 +15,7 @@ pub const Builder = struct {
         const producer_conf: ?*librdkafka.struct_rd_kafka_conf_s = librdkafka.rd_kafka_conf_new();
         if (producer_conf == null) {
             @branchHint(.unlikely);
-            @panic("failed to create config");
+            std.log.err("failed to create kafka config");
         }
         return producer_conf;
     }

--- a/src/consumer.zig
+++ b/src/consumer.zig
@@ -17,7 +17,7 @@ pub const Consumer = struct {
         const kafka_consumer: ?*librdkafka.rd_kafka_t = librdkafka.rd_kafka_new(librdkafka.RD_KAFKA_CONSUMER, kafka_conf, &error_message, error_message.len);
         if (kafka_consumer == null) {
             @branchHint(.unlikely);
-            @panic(&error_message);
+            std.log.err("Failed to initialize kafka consumer: {s}", .{error_message});
         }
         std.log.info("kafka consumer initialized", .{});
         return kafka_consumer;

--- a/src/producer.zig
+++ b/src/producer.zig
@@ -18,9 +18,10 @@ pub const Producer = struct {
         const kafka_producer: ?*librdkafka.rd_kafka_t = librdkafka.rd_kafka_new(librdkafka.RD_KAFKA_PRODUCER, kafka_conf, &err_message, err_message.len);
         if (kafka_producer == null) {
             @branchHint(.unlikely);
-            @panic(&err_message);
+            std.log.err("Failed to create producer: {s}", .{err_message});
+        } else {
+            std.log.info("kafka producer initialized", .{});
         }
-        std.log.info("kafka producer initialized", .{});
         return kafka_producer;
     }
 
@@ -56,9 +57,9 @@ pub const Producer = struct {
         );
 
         if (err_code == librdkafka.RD_KAFKA_RESP_ERR_NO_ERROR) {
-            std.log.info("Message sent successfully!", .{});
+            std.log.info("Message produced successfully!", .{});
         } else {
-            std.log.err("Failed to send message: {s}", .{errors.err2Str(err_code)});
+            std.log.err("Failed to produce message: {s}", .{errors.err2Str(err_code)});
         }
     }
 

--- a/src/topic.zig
+++ b/src/topic.zig
@@ -6,7 +6,7 @@ pub fn createTopic(client: ?*librdkafka.rd_kafka_t, topic_conf: ?*librdkafka.str
     const kafka_topic: ?*librdkafka.struct_rd_kafka_topic_s = librdkafka.rd_kafka_topic_new(client, topic_name, topic_conf);
     if (kafka_topic == null) {
         @branchHint(.unlikely);
-        @panic("Failed to create Kafka topic");
+        std.log.err("Failed to create Kafka topic", .{});
     }
     return kafka_topic;
 }
@@ -24,7 +24,7 @@ pub const Builder = struct {
         const topic_conf: ?*librdkafka.struct_rd_kafka_topic_conf_s = librdkafka.rd_kafka_topic_conf_new();
         if (topic_conf == null) {
             @branchHint(.unlikely);
-            @panic("Failed to create topic configuration");
+            std.log.err("Failed to create topic configuration", .{});
         }
         return topic_conf;
     }


### PR DESCRIPTION
For most of these, the return type is an optional so any users should be checking that on their end already.